### PR TITLE
improvement: discriminator type for structured hitl outputs

### DIFF
--- a/services/ai/langgraph/schemas/agent_outputs.py
+++ b/services/ai/langgraph/schemas/agent_outputs.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -8,10 +10,37 @@ class Question(BaseModel):
     message_type: str = Field("question", description="Type of message")
 
 
+class QuestionsAgentVariant(BaseModel):
+    """Questions for human-in-the-loop interaction."""
+    
+    type: Literal["questions"] = Field(
+        default="questions",
+        description="Discriminator field. Set to 'questions' when asking user questions."
+    )
+    items: list[Question] = Field(
+        ...,
+        description="List of questions to ask the user"
+    )
+
+
+class ContentAgentVariant(BaseModel):
+    """Content output for downstream consumers."""
+    
+    type: Literal["content"] = Field(
+        default="content",
+        description="Discriminator field. Set to 'content' when providing output."
+    )
+    content: str = Field(
+        ...,
+        description="The complete output content for downstream consumers"
+    )
+
+
 class AgentOutput(BaseModel):
     """Agent produces EITHER questions for HITL OR content for downstream consumers."""
 
-    output: list[Question] | str = Field(
+    output: QuestionsAgentVariant | ContentAgentVariant = Field(
         ...,
-        description="EITHER questions for HITL OR complete output for downstream consumers"
+        discriminator="type",
+        description="EITHER questions (type='questions') OR content (type='content')"
     )

--- a/services/ai/langgraph/schemas/expert_outputs.py
+++ b/services/ai/langgraph/schemas/expert_outputs.py
@@ -1,11 +1,30 @@
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 from .agent_outputs import Question
 
 
-class ReceiverOutputs(BaseModel):
-    """Tailored outputs for Synthesis Agent, Season Planner, and Weekly Planner."""
+class QuestionsVariant(BaseModel):
+    """Questions for human-in-the-loop interaction."""
     
+    type: Literal["questions"] = Field(
+        default="questions",
+        description="Discriminator field. Set to 'questions' when asking user questions."
+    )
+    items: list[Question] = Field(
+        ...,
+        description="List of questions to ask the user"
+    )
+
+
+class AnalysisVariant(BaseModel):
+    """Analysis outputs for downstream consumers."""
+    
+    type: Literal["analysis"] = Field(
+        default="analysis",
+        description="Discriminator field. Set to 'analysis' when providing analysis outputs."
+    )
     for_synthesis: str = Field(
         ...,
         description="Output for Synthesis Agent creating comprehensive athlete report"
@@ -23,9 +42,10 @@ class ReceiverOutputs(BaseModel):
 class ExpertOutputBase(BaseModel):
     """Expert produces EITHER questions for HITL OR outputs for downstream consumers."""
 
-    output: list[Question] | ReceiverOutputs = Field(
+    output: QuestionsVariant | AnalysisVariant = Field(
         ...,
-        description="EITHER questions for HITL OR full output for downstream consumers"
+        discriminator="type",
+        description="EITHER questions (type='questions') OR analysis outputs (type='analysis')"
     )
 
 

--- a/services/ai/langgraph/utils/output_helper.py
+++ b/services/ai/langgraph/utils/output_helper.py
@@ -1,6 +1,5 @@
-from typing import Any, TypeVar
+from typing import Any
 
-T = TypeVar("T")
 
 def extract_expert_output(expert_output: Any, target_field: str) -> str:
     if expert_output is None:
@@ -8,6 +7,13 @@ def extract_expert_output(expert_output: Any, target_field: str) -> str:
 
     if hasattr(expert_output, "output"):
         output = expert_output.output
+        
+        if hasattr(output, "type"):
+            if output.type == "questions":
+                raise ValueError("Expert output contains questions, not analysis. HITL interaction required.")
+            if output.type == "analysis":
+                if hasattr(output, target_field):
+                    return getattr(output, target_field)
         
         if isinstance(output, list):
             raise ValueError("Expert output contains questions, not analysis. HITL interaction required.")
@@ -22,8 +28,11 @@ def extract_expert_output(expert_output: Any, target_field: str) -> str:
     elif isinstance(expert_output, dict):
         if "output" in expert_output:
             output = expert_output["output"]
-            if isinstance(output, dict) and target_field in output:
-                return output[target_field]
+            if isinstance(output, dict):
+                if output.get("type") == "questions":
+                    raise ValueError("Expert output contains questions, not analysis. HITL interaction required.")
+                if target_field in output:
+                    return output[target_field]
             if isinstance(output, object) and hasattr(output, target_field):
                 return getattr(output, target_field)
         
@@ -39,11 +48,24 @@ def extract_agent_content(value: Any) -> str:
         
     if hasattr(value, "output"):
         output = value.output
+        
+        if hasattr(output, "type"):
+            if output.type == "questions":
+                raise ValueError("AgentOutput contains questions, not content. HITL interaction required.")
+            if output.type == "content":
+                return output.content
+        
         if isinstance(output, str):
             return output
         raise ValueError("AgentOutput contains questions, not content. HITL interaction required.")
         
     if isinstance(value, dict):
+        output = value.get("output", value)
+        if isinstance(output, dict):
+            if output.get("type") == "questions":
+                raise ValueError("AgentOutput contains questions, not content. HITL interaction required.")
+            if output.get("type") == "content":
+                return output.get("content", "")
         return value.get("output", value.get("content", value))
         
     if isinstance(value, str):

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -40,10 +40,10 @@ class ModelSelector:
             name="claude-sonnet-4-5-20250929", base_url="https://api.anthropic.com"
         ),
         "claude-opus": ModelConfiguration(
-            name="claude-opus-4-1-20250805", base_url="https://api.anthropic.com"
+            name="claude-opus-4-5-20251101", base_url="https://api.anthropic.com"
         ),
         "claude-opus-thinking": ModelConfiguration(
-            name="claude-opus-4-1-20250805", base_url="https://api.anthropic.com"
+            name="claude-opus-4-5-20251101", base_url="https://api.anthropic.com"
         ),
         "claude-3-haiku": ModelConfiguration(
             name="claude-3-haiku-20240307", base_url="https://api.anthropic.com"


### PR DESCRIPTION
Fixes validation errors with cheaper models structured outputs by adding a type discriminator field to union types. The explicit discriminator helps weaker models correctly choose between question and analysis output variants.
tackles #37 