### PR TITLE
Open router - Additional support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ notebooks/
 **/test_notebooks/
 **/experimental/
 my_training_config.yaml
+pixi.lock

--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,3 @@ notebooks/
 **/test_notebooks/
 **/experimental/
 my_training_config.yaml
-pixi.lock

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -137,26 +137,6 @@ class ModelSelector:
 
     @classmethod
     def get_llm(cls, role: AgentRole):
-        """
-        Get an LLM instance for the given role.
-        
-        This method implements a fallback strategy for model routing:
-        1. For Anthropic/OpenAI models: Prefer direct API if key is available
-        2. If direct API key is missing: Fall back to OpenRouter (if model has openrouter_name)
-        3. For native OpenRouter models: Always use OpenRouter API
-        
-        Provider-specific parameters (thinking, responses_api, reasoning, etc.) are automatically
-        stripped when routing through OpenRouter, as they are not supported by OpenRouter's API.
-        
-        Args:
-            role: The agent role determining which model to use
-            
-        Returns:
-            ChatAnthropic or ChatOpenAI instance configured for the selected model
-            
-        Raises:
-            RuntimeError: If required API keys are missing or model is not available via OpenRouter
-        """
         model_name = ai_settings.get_model_for_role(role)
         model_config = cls.CONFIGURATIONS[model_name]
         config = get_config()

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -138,11 +138,11 @@ class ModelSelector:
     @classmethod
     def get_llm(cls, role: AgentRole):
         model_name = ai_settings.get_model_for_role(role)
-        model_config = cls.CONFIGURATIONS[model_name]
+        selected_config = cls.CONFIGURATIONS[model_name]
         config = get_config()
         
-        base_url = model_config.base_url
-        final_model_name = model_config.name
+        base_url = selected_config.base_url
+        final_model_name = selected_config.name
         model_provider = cls._detect_provider(base_url)
         use_openrouter_fallback = False
 
@@ -153,28 +153,30 @@ class ModelSelector:
                     use_openrouter_fallback = True
                     api_key = config.openrouter_api_key
                     base_url = OPENROUTER_BASE_URL
-                    final_model_name = model_config.openrouter_name or f"anthropic/{model_config.name}"
+                    final_model_name = (
+                        selected_config.openrouter_name or f"anthropic/{selected_config.name}"
+                    )
                     logger.info(
                         "Routing Anthropic model %s through OpenRouter (no Anthropic API key available)",
-                        model_config.name,
+                        selected_config.name,
                     )
                 else:
                     raise RuntimeError("Anthropic API key or OpenRouter API key is required")
         elif model_provider == "openai":
             api_key = config.openai_api_key
             if not api_key:
-                if config.openrouter_api_key and model_config.openrouter_name:
+                if config.openrouter_api_key and selected_config.openrouter_name:
                     use_openrouter_fallback = True
                     api_key = config.openrouter_api_key
                     base_url = OPENROUTER_BASE_URL
-                    final_model_name = model_config.openrouter_name
+                    final_model_name = selected_config.openrouter_name
                     logger.info(
                         "Routing OpenAI model %s through OpenRouter (no OpenAI API key available)",
-                        model_config.name,
+                        selected_config.name,
                     )
                 elif config.openrouter_api_key:
                     raise RuntimeError(
-                        f"OpenAI model {model_config.name} is not available via OpenRouter; "
+                        f"OpenAI model {selected_config.name} is not available via OpenRouter; "
                         "provide an OPENAI_API_KEY"
                     )
                 else:

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -150,28 +150,17 @@ class ModelSelector:
             api_key = config.anthropic_api_key
             if not api_key:
                 if config.openrouter_api_key:
-                    use_openrouter_fallback = True
-                    api_key = config.openrouter_api_key
-                    base_url = OPENROUTER_BASE_URL
-                    final_model_name = (
-                        selected_config.openrouter_name or f"anthropic/{selected_config.name}"
-                    )
-                    logger.info(
-                        "Routing Anthropic model %s through OpenRouter (no Anthropic API key available)",
-                        selected_config.name,
-                    )
-                else:
-                    raise RuntimeError("Anthropic API key or OpenRouter API key is required")
-        elif model_provider == "openai":
-            api_key = config.openai_api_key
-            if not api_key:
-                if config.openrouter_api_key and selected_config.openrouter_name:
+                    if not selected_config.openrouter_name:
+                        raise RuntimeError(
+                            f"Anthropic model {selected_config.name} is not available via OpenRouter; "
+                            "provide an ANTHROPIC_API_KEY"
+                        )
                     use_openrouter_fallback = True
                     api_key = config.openrouter_api_key
                     base_url = OPENROUTER_BASE_URL
                     final_model_name = selected_config.openrouter_name
                     logger.info(
-                        "Routing OpenAI model %s through OpenRouter (no OpenAI API key available)",
+                        "Routing Anthropic model %s through OpenRouter (no Anthropic API key available)",
                         selected_config.name,
                     )
                 elif config.openrouter_api_key:

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -213,6 +213,8 @@ class ModelSelector:
 
         if base_url == openrouter_base:
             llm_params.pop("use_responses_api", None)
+            llm_params.pop("reasoning", None)
+            llm_params.pop("model_kwargs", None)
             if model_provider == "anthropic":
                 llm_params.pop("thinking", None)
 

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -25,15 +25,6 @@ class ModelSelector:
 
     @staticmethod
     def _detect_provider(base_url: str) -> str:
-        """
-        Detect the model provider from the base URL.
-        
-        Args:
-            base_url: The base URL of the model API
-            
-        Returns:
-            One of: "anthropic", "openai", or "openrouter"
-        """
         if "anthropic" in base_url:
             return "anthropic"
         elif "openai.com" in base_url:

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -143,51 +143,37 @@ class ModelSelector:
         
         base_url = selected_config.base_url
         final_model_name = selected_config.name
-        model_provider = cls._detect_provider(base_url)
-        use_openrouter_fallback = False
-
-        if model_provider == "anthropic":
-            api_key = config.anthropic_api_key
-            if not api_key:
-                if config.openrouter_api_key:
-                    if not selected_config.openrouter_name:
-                        raise RuntimeError(
-                            f"Anthropic model {selected_config.name} is not available via OpenRouter; "
-                            "provide an ANTHROPIC_API_KEY"
-                        )
-                    use_openrouter_fallback = True
-                    api_key = config.openrouter_api_key
-                    base_url = OPENROUTER_BASE_URL
-                    final_model_name = selected_config.openrouter_name
-                    logger.info(
-                        "Routing Anthropic model %s through OpenRouter (no Anthropic API key available)",
-                        selected_config.name,
-                    )
-                else:
-                    raise RuntimeError("Anthropic API key or OpenRouter API key is required")
-        elif model_provider == "openai":
-            api_key = config.openai_api_key
-            if not api_key:
-                if config.openrouter_api_key:
-                    if not selected_config.openrouter_name:
-                        raise RuntimeError(
-                            f"OpenAI model {selected_config.name} is not available via OpenRouter; "
-                            "provide an OPENAI_API_KEY"
-                        )
-                    use_openrouter_fallback = True
-                    api_key = config.openrouter_api_key
-                    base_url = OPENROUTER_BASE_URL
-                    final_model_name = selected_config.openrouter_name
-                    logger.info(
-                        "Routing OpenAI model %s through OpenRouter (no OpenAI API key available)",
-                        selected_config.name,
-                    )
-                else:
-                    raise RuntimeError("OpenAI API key or OpenRouter API key is required")
-        else:
+        provider = cls._detect_provider(base_url)
+        
+        key_map = {
+            "anthropic": config.anthropic_api_key,
+            "openai": config.openai_api_key,
+            "openrouter": config.openrouter_api_key,
+        }
+        
+        api_key = key_map.get(provider)
+        use_fallback = False
+        
+        if not api_key and provider in ("anthropic", "openai"):
+            if not config.openrouter_api_key:
+                raise RuntimeError(f"{provider.title()} API key or OpenRouter API key is required")
+            if not selected_config.openrouter_name:
+                raise RuntimeError(
+                    f"{provider.title()} model {selected_config.name} is not available via OpenRouter; "
+                    f"provide an {provider.upper()}_API_KEY"
+                )
             api_key = config.openrouter_api_key
-            if not api_key:
-                raise RuntimeError("OpenRouter API key is required for OpenRouter-hosted models")
+            base_url = OPENROUTER_BASE_URL
+            final_model_name = selected_config.openrouter_name
+            use_fallback = True
+            logger.info(
+                "Routing %s model %s through OpenRouter (no %s API key available)",
+                provider.title(),
+                selected_config.name,
+                provider.title(),
+            )
+        elif not api_key:
+            raise RuntimeError("OpenRouter API key is required for OpenRouter-hosted models")
 
         logger.info(f"Configuring LLM for role {role.value} with model {final_model_name}")
         
@@ -243,10 +229,10 @@ class ModelSelector:
             llm_params.pop("use_responses_api", None)
             llm_params.pop("reasoning", None)
             llm_params.pop("model_kwargs", None)
-            if model_provider == "anthropic":
+            if provider == "anthropic":
                 llm_params.pop("thinking", None)
 
-        if model_provider == "anthropic" and not use_openrouter_fallback:
+        if provider == "anthropic" and not use_fallback:
             return ChatAnthropic(**llm_params)
 
         llm_params["base_url"] = base_url

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -15,35 +15,76 @@ logger = logging.getLogger(__name__)
 class ModelConfiguration:
     name: str
     base_url: str
+    openrouter_name: str | None = None
 
 
 class ModelSelector:
 
     CONFIGURATIONS: dict[str, ModelConfiguration] = {
         # OpenAI Models
-        "gpt-4o": ModelConfiguration(name="gpt-4o", base_url="https://api.openai.com/v1"),
-        "gpt-4.1": ModelConfiguration(name="gpt-4.1", base_url="https://api.openai.com/v1"),
+        "gpt-4o": ModelConfiguration(
+            name="gpt-4o",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/gpt-4o",
+        ),
+        "gpt-4.1": ModelConfiguration(
+            name="gpt-4.1",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/gpt-4.1",
+        ),
         "gpt-4.5": ModelConfiguration(name="gpt-4.5-preview", base_url="https://api.openai.com/v1"),
-        "gpt-4o-mini": ModelConfiguration(name="gpt-4o-mini", base_url="https://api.openai.com/v1"),
+        "gpt-4o-mini": ModelConfiguration(
+            name="gpt-4o-mini",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/gpt-4o-mini",
+        ),
         "o1": ModelConfiguration(name="o1-preview", base_url="https://api.openai.com/v1"),
         "o1-mini": ModelConfiguration(name="o1-mini", base_url="https://api.openai.com/v1"),
-        "o3": ModelConfiguration(name="o3", base_url="https://api.openai.com/v1"),
-        "o3-mini": ModelConfiguration(name="o3-mini", base_url="https://api.openai.com/v1"),
-        "o4-mini": ModelConfiguration(name="o4-mini", base_url="https://api.openai.com/v1"),
-        "gpt-5": ModelConfiguration(name="gpt-5.1", base_url="https://api.openai.com/v1"),
-        "gpt-5-mini": ModelConfiguration(name="gpt-5-mini", base_url="https://api.openai.com/v1"),
+        "o3": ModelConfiguration(
+            name="o3",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/o3",
+        ),
+        "o3-mini": ModelConfiguration(
+            name="o3-mini",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/o3-mini",
+        ),
+        "o4-mini": ModelConfiguration(
+            name="o4-mini",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/o4-mini",
+        ),
+        "gpt-5": ModelConfiguration(
+            name="gpt-5.1",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/gpt-5.1",
+        ),
+        "gpt-5-mini": ModelConfiguration(
+            name="gpt-5-mini",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/gpt-5-mini",
+        ),
         # Anthropic Models
         "claude-4": ModelConfiguration(
-            name="claude-sonnet-4-5-20250929", base_url="https://api.anthropic.com"
+            name="claude-sonnet-4-5-20250929",
+            base_url="https://api.anthropic.com",
+            openrouter_name="anthropic/claude-sonnet-4.5",
         ),
         "claude-4-thinking": ModelConfiguration(
-            name="claude-sonnet-4-5-20250929", base_url="https://api.anthropic.com"
+            name="claude-sonnet-4-5-20250929",
+            base_url="https://api.anthropic.com",
+            openrouter_name="anthropic/claude-sonnet-4.5",
         ),
         "claude-opus": ModelConfiguration(
-            name="claude-opus-4-1-20250805", base_url="https://api.anthropic.com"
+            name="claude-opus-4-1-20250805",
+            base_url="https://api.anthropic.com",
+            openrouter_name="anthropic/claude-opus-4.1",
         ),
         "claude-opus-thinking": ModelConfiguration(
-            name="claude-opus-4-1-20250805", base_url="https://api.anthropic.com"
+            name="claude-opus-4-1-20250805",
+            base_url="https://api.anthropic.com",
+            openrouter_name="anthropic/claude-opus-4.1",
         ),
         "claude-3-haiku": ModelConfiguration(
             name="claude-3-haiku-20240307", base_url="https://api.anthropic.com"
@@ -74,15 +115,57 @@ class ModelSelector:
         model_config = cls.CONFIGURATIONS[model_name]
         config = get_config()
         
-        api_key_map = {
-            "anthropic": config.anthropic_api_key,
-            "openrouter": config.openrouter_api_key,
-        }
-        api_key = next((api_key_map[k] for k in api_key_map if k in model_config.base_url), config.openai_api_key)
+        base_url = model_config.base_url
+        final_model_name = model_config.name
+        model_provider = "openrouter"
+        if "anthropic" in base_url:
+            model_provider = "anthropic"
+        elif "openai.com" in base_url:
+            model_provider = "openai"
+        use_openrouter_fallback = False
+        openrouter_base = "https://openrouter.ai/api/v1"
 
-        logger.info(f"Configuring LLM for role {role.value} with model {model_config.name}")
+        if model_provider == "anthropic":
+            api_key = config.anthropic_api_key
+            if not api_key:
+                if config.openrouter_api_key:
+                    use_openrouter_fallback = True
+                    api_key = config.openrouter_api_key
+                    base_url = openrouter_base
+                    final_model_name = model_config.openrouter_name or f"anthropic/{model_config.name}"
+                    logger.info(
+                        "Routing Anthropic model %s through OpenRouter (no Anthropic API key available)",
+                        model_config.name,
+                    )
+                else:
+                    raise RuntimeError("Anthropic API key or OpenRouter API key is required")
+        elif model_provider == "openai":
+            api_key = config.openai_api_key
+            if not api_key:
+                if config.openrouter_api_key and model_config.openrouter_name:
+                    use_openrouter_fallback = True
+                    api_key = config.openrouter_api_key
+                    base_url = openrouter_base
+                    final_model_name = model_config.openrouter_name
+                    logger.info(
+                        "Routing OpenAI model %s through OpenRouter (no OpenAI API key available)",
+                        model_config.name,
+                    )
+                elif config.openrouter_api_key:
+                    raise RuntimeError(
+                        f"OpenAI model {model_config.name} is not available via OpenRouter; "
+                        "provide an OPENAI_API_KEY"
+                    )
+                else:
+                    raise RuntimeError("OpenAI API key or OpenRouter API key is required")
+        else:
+            api_key = config.openrouter_api_key
+            if not api_key:
+                raise RuntimeError("OpenRouter API key is required for OpenRouter-hosted models")
 
-        llm_params = {"model": model_config.name, "api_key": api_key}
+        logger.info(f"Configuring LLM for role {role.value} with model {final_model_name}")
+        
+        llm_params = {"model": final_model_name, "api_key": api_key}
         
         model_configs = {
             "claude-opus-thinking": {
@@ -122,14 +205,19 @@ class ModelSelector:
         }
         
         if model_name in model_configs:
-            config_data = model_configs[model_name]
+            config_data = model_configs[model_name].copy()
             log_msg = config_data.pop("log", None)
             llm_params.update(config_data)
             if log_msg:
                 logger.info(log_msg.format(role=role.value))
 
-        if "anthropic" in model_config.base_url:
+        if base_url == openrouter_base:
+            llm_params.pop("use_responses_api", None)
+            if model_provider == "anthropic":
+                llm_params.pop("thinking", None)
+
+        if model_provider == "anthropic" and not use_openrouter_fallback:
             return ChatAnthropic(**llm_params)
-        
-        llm_params["base_url"] = model_config.base_url
+
+        llm_params["base_url"] = base_url
         return ChatOpenAI(**llm_params)

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -10,7 +10,6 @@ from .ai_settings import AgentRole, ai_settings
 
 logger = logging.getLogger(__name__)
 
-# OpenRouter API base URL
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -122,8 +122,8 @@ class ModelSelector:
         "deepseek-reasoner": ModelConfiguration(
             name="openrouter/deepseek/deepseek-r1", base_url=OPENROUTER_BASE_URL
         ),
-        "deepseek-v3.2-exp": ModelConfiguration(
-            name="deepseek/deepseek-v3.2-exp", base_url=OPENROUTER_BASE_URL
+        "deepseek-v3.2": ModelConfiguration(
+            name="deepseek/deepseek-v3.2", base_url=OPENROUTER_BASE_URL
         ),
         # Google Models (via OpenRouter)
         "gemini-2.5-pro": ModelConfiguration(
@@ -138,7 +138,9 @@ class ModelSelector:
     @classmethod
     def get_llm(cls, role: AgentRole):
         model_name = ai_settings.get_model_for_role(role)
-        selected_config = cls.CONFIGURATIONS[model_name]
+        selected_config = cls.CONFIGURATIONS.get(model_name)
+        if not selected_config:
+            raise RuntimeError(f"Unknown model '{model_name}' in configuration")
         config = get_config()
         
         base_url = selected_config.base_url
@@ -210,9 +212,9 @@ class ModelSelector:
                 "model_kwargs": {"text": {"verbosity": "high"}},
                 "log": "Using GPT-5-mini with Responses API for {role} (verbosity: high, reasoning_effort: high)",
             },
-            "deepseek-v3.2-exp": {
+            "deepseek-v3.2": {
                 "extra_body": {"reasoning": {"enabled": True}},
-                "log": "Using DeepSeek V3.2 Exp with reasoning enabled for {role}",
+                "log": "Using DeepSeek V3.2 with reasoning enabled for {role}",
             },
         }
         
@@ -229,11 +231,13 @@ class ModelSelector:
             llm_params.pop("use_responses_api", None)
             llm_params.pop("reasoning", None)
             llm_params.pop("model_kwargs", None)
+            llm_params.pop("extra_body", None)
             if provider == "anthropic":
                 llm_params.pop("thinking", None)
 
         if provider == "anthropic" and not use_fallback:
             return ChatAnthropic(**llm_params)
 
-        llm_params["base_url"] = base_url
+        if base_url == OPENROUTER_BASE_URL:
+            llm_params["base_url"] = base_url
         return ChatOpenAI(**llm_params)

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -168,7 +168,12 @@ class ModelSelector:
         elif model_provider == "openai":
             api_key = config.openai_api_key
             if not api_key:
-                if config.openrouter_api_key and selected_config.openrouter_name:
+                if config.openrouter_api_key:
+                    if not selected_config.openrouter_name:
+                        raise RuntimeError(
+                            f"OpenAI model {selected_config.name} is not available via OpenRouter; "
+                            "provide an OPENAI_API_KEY"
+                        )
                     use_openrouter_fallback = True
                     api_key = config.openrouter_api_key
                     base_url = OPENROUTER_BASE_URL
@@ -176,11 +181,6 @@ class ModelSelector:
                     logger.info(
                         "Routing OpenAI model %s through OpenRouter (no OpenAI API key available)",
                         selected_config.name,
-                    )
-                elif config.openrouter_api_key:
-                    raise RuntimeError(
-                        f"OpenAI model {selected_config.name} is not available via OpenRouter; "
-                        "provide an OPENAI_API_KEY"
                     )
                 else:
                     raise RuntimeError("OpenAI API key or OpenRouter API key is required")

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -10,6 +10,9 @@ from .ai_settings import AgentRole, ai_settings
 
 logger = logging.getLogger(__name__)
 
+# OpenRouter API base URL
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
 
 @dataclass
 class ModelConfiguration:
@@ -19,6 +22,24 @@ class ModelConfiguration:
 
 
 class ModelSelector:
+
+    @staticmethod
+    def _detect_provider(base_url: str) -> str:
+        """
+        Detect the model provider from the base URL.
+        
+        Args:
+            base_url: The base URL of the model API
+            
+        Returns:
+            One of: "anthropic", "openai", or "openrouter"
+        """
+        if "anthropic" in base_url:
+            return "anthropic"
+        elif "openai.com" in base_url:
+            return "openai"
+        else:
+            return "openrouter"
 
     CONFIGURATIONS: dict[str, ModelConfiguration] = {
         # OpenAI Models
@@ -32,14 +53,26 @@ class ModelSelector:
             base_url="https://api.openai.com/v1",
             openrouter_name="openai/gpt-4.1",
         ),
-        "gpt-4.5": ModelConfiguration(name="gpt-4.5-preview", base_url="https://api.openai.com/v1"),
+        "gpt-4.5": ModelConfiguration(
+            name="gpt-4.5-preview",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/gpt-4.5-preview",
+        ),
         "gpt-4o-mini": ModelConfiguration(
             name="gpt-4o-mini",
             base_url="https://api.openai.com/v1",
             openrouter_name="openai/gpt-4o-mini",
         ),
-        "o1": ModelConfiguration(name="o1-preview", base_url="https://api.openai.com/v1"),
-        "o1-mini": ModelConfiguration(name="o1-mini", base_url="https://api.openai.com/v1"),
+        "o1": ModelConfiguration(
+            name="o1-preview",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/o1-preview",
+        ),
+        "o1-mini": ModelConfiguration(
+            name="o1-mini",
+            base_url="https://api.openai.com/v1",
+            openrouter_name="openai/o1-mini",
+        ),
         "o3": ModelConfiguration(
             name="o3",
             base_url="https://api.openai.com/v1",
@@ -87,43 +120,60 @@ class ModelSelector:
             openrouter_name="anthropic/claude-opus-4.1",
         ),
         "claude-3-haiku": ModelConfiguration(
-            name="claude-3-haiku-20240307", base_url="https://api.anthropic.com"
+            name="claude-3-haiku-20240307",
+            base_url="https://api.anthropic.com",
+            openrouter_name="anthropic/claude-3-haiku",
         ),
         # DeepSeek Models
         "deepseek-chat": ModelConfiguration(
-            name="openrouter/deepseek/deepseek-chat", base_url="https://openrouter.ai/api/v1"
+            name="openrouter/deepseek/deepseek-chat", base_url=OPENROUTER_BASE_URL
         ),
         "deepseek-reasoner": ModelConfiguration(
-            name="openrouter/deepseek/deepseek-r1", base_url="https://openrouter.ai/api/v1"
+            name="openrouter/deepseek/deepseek-r1", base_url=OPENROUTER_BASE_URL
         ),
         "deepseek-v3.2-exp": ModelConfiguration(
-            name="deepseek/deepseek-v3.2-exp", base_url="https://openrouter.ai/api/v1"
+            name="deepseek/deepseek-v3.2-exp", base_url=OPENROUTER_BASE_URL
         ),
         # Google Models (via OpenRouter)
         "gemini-2.5-pro": ModelConfiguration(
-            name="google/gemini-2.5-pro", base_url="https://openrouter.ai/api/v1"
+            name="google/gemini-2.5-pro", base_url=OPENROUTER_BASE_URL
         ),
         # xAI Models (via OpenRouter)
         "grok-4": ModelConfiguration(
-            name="x-ai/grok-4", base_url="https://openrouter.ai/api/v1"
+            name="x-ai/grok-4", base_url=OPENROUTER_BASE_URL
         ),
     }
 
     @classmethod
     def get_llm(cls, role: AgentRole):
+        """
+        Get an LLM instance for the given role.
+        
+        This method implements a fallback strategy for model routing:
+        1. For Anthropic/OpenAI models: Prefer direct API if key is available
+        2. If direct API key is missing: Fall back to OpenRouter (if model has openrouter_name)
+        3. For native OpenRouter models: Always use OpenRouter API
+        
+        Provider-specific parameters (thinking, responses_api, reasoning, etc.) are automatically
+        stripped when routing through OpenRouter, as they are not supported by OpenRouter's API.
+        
+        Args:
+            role: The agent role determining which model to use
+            
+        Returns:
+            ChatAnthropic or ChatOpenAI instance configured for the selected model
+            
+        Raises:
+            RuntimeError: If required API keys are missing or model is not available via OpenRouter
+        """
         model_name = ai_settings.get_model_for_role(role)
         model_config = cls.CONFIGURATIONS[model_name]
         config = get_config()
         
         base_url = model_config.base_url
         final_model_name = model_config.name
-        model_provider = "openrouter"
-        if "anthropic" in base_url:
-            model_provider = "anthropic"
-        elif "openai.com" in base_url:
-            model_provider = "openai"
+        model_provider = cls._detect_provider(base_url)
         use_openrouter_fallback = False
-        openrouter_base = "https://openrouter.ai/api/v1"
 
         if model_provider == "anthropic":
             api_key = config.anthropic_api_key
@@ -131,7 +181,7 @@ class ModelSelector:
                 if config.openrouter_api_key:
                     use_openrouter_fallback = True
                     api_key = config.openrouter_api_key
-                    base_url = openrouter_base
+                    base_url = OPENROUTER_BASE_URL
                     final_model_name = model_config.openrouter_name or f"anthropic/{model_config.name}"
                     logger.info(
                         "Routing Anthropic model %s through OpenRouter (no Anthropic API key available)",
@@ -145,7 +195,7 @@ class ModelSelector:
                 if config.openrouter_api_key and model_config.openrouter_name:
                     use_openrouter_fallback = True
                     api_key = config.openrouter_api_key
-                    base_url = openrouter_base
+                    base_url = OPENROUTER_BASE_URL
                     final_model_name = model_config.openrouter_name
                     logger.info(
                         "Routing OpenAI model %s through OpenRouter (no OpenAI API key available)",
@@ -211,7 +261,9 @@ class ModelSelector:
             if log_msg:
                 logger.info(log_msg.format(role=role.value))
 
-        if base_url == openrouter_base:
+        if base_url == OPENROUTER_BASE_URL:
+            # Strip provider-specific parameters when routing through OpenRouter
+            # as they are not supported by OpenRouter's API
             llm_params.pop("use_responses_api", None)
             llm_params.pop("reasoning", None)
             llm_params.pop("model_kwargs", None)

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -237,6 +237,5 @@ class ModelSelector:
         if provider == "anthropic" and not use_fallback:
             return ChatAnthropic(**llm_params)
 
-        if base_url == OPENROUTER_BASE_URL:
-            llm_params["base_url"] = base_url
+        llm_params["base_url"] = base_url
         return ChatOpenAI(**llm_params)

--- a/services/ai/model_config.py
+++ b/services/ai/model_config.py
@@ -163,6 +163,20 @@ class ModelSelector:
                         "Routing Anthropic model %s through OpenRouter (no Anthropic API key available)",
                         selected_config.name,
                     )
+                else:
+                    raise RuntimeError("Anthropic API key or OpenRouter API key is required")
+        elif model_provider == "openai":
+            api_key = config.openai_api_key
+            if not api_key:
+                if config.openrouter_api_key and selected_config.openrouter_name:
+                    use_openrouter_fallback = True
+                    api_key = config.openrouter_api_key
+                    base_url = OPENROUTER_BASE_URL
+                    final_model_name = selected_config.openrouter_name
+                    logger.info(
+                        "Routing OpenAI model %s through OpenRouter (no OpenAI API key available)",
+                        selected_config.name,
+                    )
                 elif config.openrouter_api_key:
                     raise RuntimeError(
                         f"OpenAI model {selected_config.name} is not available via OpenRouter; "

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -16,32 +16,50 @@ class _StubSettings:
         return self.model_name
 
 
-def test_prefers_direct_anthropic_when_key_available(monkeypatch):
-    config = Config(
-        anthropic_api_key="sk-ant-api03-test",
-        openrouter_api_key="sk-or-test",
-        ai_mode=AIMode.STANDARD,
-    )
+@pytest.mark.parametrize(
+    ("model_name", "api_key_field", "expected_model", "expected_client"),
+    [
+        ("claude-4", "anthropic_api_key", "claude-sonnet-4-5-20250929", "ChatAnthropic"),
+        ("gpt-4o", "openai_api_key", "gpt-4o", "ChatOpenAI"),
+    ],
+)
+def test_prefers_direct_api_when_key_available(
+    monkeypatch, model_name, api_key_field, expected_model, expected_client
+):
+    api_key_values = {
+        "anthropic_api_key": "sk-ant-api03-test",
+        "openai_api_key": "sk-test",
+    }
+    config_dict = {
+        api_key_field: api_key_values[api_key_field],
+        "openrouter_api_key": "sk-or-test",
+        "ai_mode": AIMode.STANDARD,
+    }
+    config = Config(**config_dict)
     monkeypatch.setattr(model_config, "get_config", lambda: config)
-    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("claude-4"))
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings(model_name))
 
     captured = {}
 
     def fake_chat_anthropic(**kwargs):
         captured.update(kwargs)
+        captured["client"] = "ChatAnthropic"
         return types.SimpleNamespace(**kwargs)
 
-    def fake_chat_openai(**_kwargs):
-        raise AssertionError("ChatOpenAI should not be used when Anthropic key is present")
+    def fake_chat_openai(**kwargs):
+        captured.update(kwargs)
+        captured["client"] = "ChatOpenAI"
+        return types.SimpleNamespace(**kwargs)
 
     monkeypatch.setattr(model_config, "ChatAnthropic", fake_chat_anthropic)
     monkeypatch.setattr(model_config, "ChatOpenAI", fake_chat_openai)
 
     ModelSelector.get_llm(AgentRole.SUMMARIZER)
 
-    assert captured["model"] == "claude-sonnet-4-5-20250929"
-    assert captured["api_key"] == "sk-ant-api03-test"
+    assert captured["model"] == expected_model
+    assert captured["api_key"] == api_key_values[api_key_field]
     assert "base_url" not in captured
+    assert captured["client"] == expected_client
 
 
 @pytest.mark.parametrize(

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -172,7 +172,7 @@ def test_openai_responses_params_stripped_for_openrouter(monkeypatch, model_name
     [
         ("deepseek-chat", "openrouter/deepseek/deepseek-chat"),
         ("deepseek-reasoner", "openrouter/deepseek/deepseek-r1"),
-        ("deepseek-v3.2-exp", "deepseek/deepseek-v3.2-exp"),
+        ("deepseek-v3.2", "deepseek/deepseek-v3.2"),
         ("gemini-2.5-pro", "google/gemini-2.5-pro"),
         ("grok-4", "x-ai/grok-4"),
     ],

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -5,7 +5,7 @@ import pytest
 from core.config import AIMode, Config
 from services.ai import model_config
 from services.ai.ai_settings import AgentRole
-from services.ai.model_config import ModelSelector, OPENROUTER_BASE_URL
+from services.ai.model_config import OPENROUTER_BASE_URL, ModelSelector
 
 
 class _StubSettings:

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -58,7 +58,10 @@ def test_prefers_direct_api_when_key_available(
 
     assert captured["model"] == expected_model
     assert captured["api_key"] == api_key_values[api_key_field]
-    assert "base_url" not in captured
+    if expected_client == "ChatOpenAI":
+        assert captured["base_url"] == "https://api.openai.com/v1"
+    else:
+        assert "base_url" not in captured
     assert captured["client"] == expected_client
 
 

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,132 @@
+import types
+
+import pytest
+
+from core.config import AIMode, Config
+from services.ai.ai_settings import AgentRole
+import services.ai.model_config as model_config
+from services.ai.model_config import ModelSelector
+
+
+class _StubSettings:
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+
+    def get_model_for_role(self, _: AgentRole) -> str:
+        return self.model_name
+
+
+def test_prefers_direct_anthropic_when_key_available(monkeypatch):
+    config = Config(
+        anthropic_api_key="sk-ant-api03-test",
+        openrouter_api_key="sk-or-test",
+        ai_mode=AIMode.STANDARD,
+    )
+    monkeypatch.setattr(model_config, "get_config", lambda: config)
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("claude-4"))
+
+    captured = {}
+
+    def fake_chat_anthropic(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(**kwargs)
+
+    def fake_chat_openai(**_kwargs):
+        raise AssertionError("ChatOpenAI should not be used when Anthropic key is present")
+
+    monkeypatch.setattr(model_config, "ChatAnthropic", fake_chat_anthropic)
+    monkeypatch.setattr(model_config, "ChatOpenAI", fake_chat_openai)
+
+    ModelSelector.get_llm(AgentRole.SUMMARIZER)
+
+    assert captured["model"] == "claude-sonnet-4-5-20250929"
+    assert captured["api_key"] == "sk-ant-api03-test"
+    assert "base_url" not in captured
+
+
+def test_routes_anthropic_through_openrouter_when_missing_key(monkeypatch):
+    config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
+    monkeypatch.setattr(model_config, "get_config", lambda: config)
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("claude-4-thinking"))
+
+    captured = {}
+
+    def fake_chat_openai(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(**kwargs)
+
+    def fake_chat_anthropic(**_kwargs):
+        raise AssertionError("ChatAnthropic should not be used when routing via OpenRouter")
+
+    monkeypatch.setattr(model_config, "ChatOpenAI", fake_chat_openai)
+    monkeypatch.setattr(model_config, "ChatAnthropic", fake_chat_anthropic)
+
+    ModelSelector.get_llm(AgentRole.SUMMARIZER)
+
+    assert captured["model"] == "anthropic/claude-sonnet-4.5"
+    assert captured["api_key"] == "sk-or-test"
+    assert captured["base_url"] == "https://openrouter.ai/api/v1"
+    assert "thinking" not in captured
+    assert "use_responses_api" not in captured
+
+
+def test_routes_openai_through_openrouter_when_missing_key(monkeypatch):
+    config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
+    monkeypatch.setattr(model_config, "get_config", lambda: config)
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("gpt-4o"))
+
+    captured = {}
+
+    def fake_chat_openai(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(**kwargs)
+
+    def fake_chat_anthropic(**_kwargs):
+        raise AssertionError("ChatAnthropic should never be used for OpenAI models")
+
+    monkeypatch.setattr(model_config, "ChatOpenAI", fake_chat_openai)
+    monkeypatch.setattr(model_config, "ChatAnthropic", fake_chat_anthropic)
+
+    ModelSelector.get_llm(AgentRole.SUMMARIZER)
+
+    assert captured["model"] == "openai/gpt-4o"
+    assert captured["api_key"] == "sk-or-test"
+    assert captured["base_url"] == "https://openrouter.ai/api/v1"
+    assert "use_responses_api" not in captured
+
+
+def test_routes_openai_gpt5_through_openrouter_and_strips_responses_api(monkeypatch):
+    config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
+    monkeypatch.setattr(model_config, "get_config", lambda: config)
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("gpt-5"))
+
+    captured = {}
+
+    def fake_chat_openai(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(**kwargs)
+
+    def fake_chat_anthropic(**_kwargs):
+        raise AssertionError("ChatAnthropic should never be used for OpenAI models")
+
+    monkeypatch.setattr(model_config, "ChatOpenAI", fake_chat_openai)
+    monkeypatch.setattr(model_config, "ChatAnthropic", fake_chat_anthropic)
+
+    ModelSelector.get_llm(AgentRole.SUMMARIZER)
+
+    assert captured["model"] == "openai/gpt-5.1"
+    assert captured["api_key"] == "sk-or-test"
+    assert captured["base_url"] == "https://openrouter.ai/api/v1"
+    assert "use_responses_api" not in captured
+
+
+def test_openai_model_without_openrouter_alias_requires_openai_key(monkeypatch):
+    config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
+    monkeypatch.setattr(model_config, "get_config", lambda: config)
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("gpt-4.5"))
+
+    monkeypatch.setattr(model_config, "ChatOpenAI", lambda **_kwargs: None)
+    monkeypatch.setattr(model_config, "ChatAnthropic", lambda **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="not available via OpenRouter"):
+        ModelSelector.get_llm(AgentRole.SUMMARIZER)

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -149,8 +149,6 @@ def test_openai_responses_params_stripped_for_openrouter(monkeypatch, model_name
     assert "model_kwargs" not in captured
 
 
-
-
 @pytest.mark.parametrize(
     ("model_name", "expected_model_name"),
     [

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -5,7 +5,7 @@ import pytest
 from core.config import AIMode, Config
 from services.ai import model_config
 from services.ai.ai_settings import AgentRole
-from services.ai.model_config import ModelSelector
+from services.ai.model_config import ModelSelector, OPENROUTER_BASE_URL
 
 
 class _StubSettings:
@@ -44,10 +44,20 @@ def test_prefers_direct_anthropic_when_key_available(monkeypatch):
     assert "base_url" not in captured
 
 
-def test_routes_anthropic_through_openrouter_when_missing_key(monkeypatch):
+@pytest.mark.parametrize(
+    ("model_name", "expected_openrouter_name"),
+    [
+        ("claude-4", "anthropic/claude-sonnet-4.5"),
+        ("claude-4-thinking", "anthropic/claude-sonnet-4.5"),
+        ("claude-3-haiku", "anthropic/claude-3-haiku"),
+    ],
+)
+def test_routes_anthropic_through_openrouter_when_missing_key(
+    monkeypatch, model_name, expected_openrouter_name
+):
     config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
     monkeypatch.setattr(model_config, "get_config", lambda: config)
-    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("claude-4-thinking"))
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings(model_name))
 
     captured = {}
 
@@ -63,9 +73,9 @@ def test_routes_anthropic_through_openrouter_when_missing_key(monkeypatch):
 
     ModelSelector.get_llm(AgentRole.SUMMARIZER)
 
-    assert captured["model"] == "anthropic/claude-sonnet-4.5"
+    assert captured["model"] == expected_openrouter_name
     assert captured["api_key"] == "sk-or-test"
-    assert captured["base_url"] == "https://openrouter.ai/api/v1"
+    assert captured["base_url"] == OPENROUTER_BASE_URL
     assert "thinking" not in captured
     assert "use_responses_api" not in captured
 
@@ -75,7 +85,10 @@ def test_routes_anthropic_through_openrouter_when_missing_key(monkeypatch):
     [
         ("gpt-4.1", "openai/gpt-4.1"),
         ("gpt-4o", "openai/gpt-4o"),
+        ("gpt-4.5", "openai/gpt-4.5-preview"),
         ("gpt-4o-mini", "openai/gpt-4o-mini"),
+        ("o1", "openai/o1-preview"),
+        ("o1-mini", "openai/o1-mini"),
         ("o3", "openai/o3"),
         ("o3-mini", "openai/o3-mini"),
         ("o4-mini", "openai/o4-mini"),
@@ -106,7 +119,7 @@ def test_routes_openai_through_openrouter_when_missing_key(
 
     assert captured["model"] == expected_openrouter_name
     assert captured["api_key"] == "sk-or-test"
-    assert captured["base_url"] == "https://openrouter.ai/api/v1"
+    assert captured["base_url"] == OPENROUTER_BASE_URL
     assert "use_responses_api" not in captured
 
 
@@ -130,20 +143,59 @@ def test_openai_responses_params_stripped_for_openrouter(monkeypatch, model_name
 
     ModelSelector.get_llm(AgentRole.SUMMARIZER)
 
-    assert captured["base_url"] == "https://openrouter.ai/api/v1"
+    assert captured["base_url"] == OPENROUTER_BASE_URL
     assert "use_responses_api" not in captured
     assert "reasoning" not in captured
     assert "model_kwargs" not in captured
 
 
-@pytest.mark.parametrize("model_name", ["gpt-4.5", "o1", "o1-mini"])
-def test_openai_model_without_openrouter_alias_requires_openai_key(monkeypatch, model_name):
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_model_name"),
+    [
+        ("deepseek-chat", "openrouter/deepseek/deepseek-chat"),
+        ("deepseek-reasoner", "openrouter/deepseek/deepseek-r1"),
+        ("deepseek-v3.2-exp", "deepseek/deepseek-v3.2-exp"),
+        ("gemini-2.5-pro", "google/gemini-2.5-pro"),
+        ("grok-4", "x-ai/grok-4"),
+    ],
+)
+def test_native_openrouter_models_use_openrouter(monkeypatch, model_name, expected_model_name):
     config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
+    monkeypatch.setattr(model_config, "get_config", lambda: config)
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings(model_name))
+
+    captured = {}
+
+    def fake_chat_openai(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(**kwargs)
+
+    def fake_chat_anthropic(**_kwargs):
+        raise AssertionError("ChatAnthropic should never be used for OpenRouter-native models")
+
+    monkeypatch.setattr(model_config, "ChatOpenAI", fake_chat_openai)
+    monkeypatch.setattr(model_config, "ChatAnthropic", fake_chat_anthropic)
+
+    ModelSelector.get_llm(AgentRole.SUMMARIZER)
+
+    assert captured["model"] == expected_model_name
+    assert captured["api_key"] == "sk-or-test"
+    assert captured["base_url"] == OPENROUTER_BASE_URL
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["deepseek-chat", "deepseek-reasoner", "gemini-2.5-pro", "grok-4"],
+)
+def test_native_openrouter_models_require_openrouter_key(monkeypatch, model_name):
+    config = Config(ai_mode=AIMode.STANDARD)
     monkeypatch.setattr(model_config, "get_config", lambda: config)
     monkeypatch.setattr(model_config, "ai_settings", _StubSettings(model_name))
 
     monkeypatch.setattr(model_config, "ChatOpenAI", lambda **_kwargs: None)
     monkeypatch.setattr(model_config, "ChatAnthropic", lambda **_kwargs: None)
 
-    with pytest.raises(RuntimeError, match="not available via OpenRouter"):
+    with pytest.raises(RuntimeError, match="OpenRouter API key is required for OpenRouter-hosted models"):
         ModelSelector.get_llm(AgentRole.SUMMARIZER)

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -3,8 +3,8 @@ import types
 import pytest
 
 from core.config import AIMode, Config
+from services.ai import model_config
 from services.ai.ai_settings import AgentRole
-import services.ai.model_config as model_config
 from services.ai.model_config import ModelSelector
 
 
@@ -70,10 +70,25 @@ def test_routes_anthropic_through_openrouter_when_missing_key(monkeypatch):
     assert "use_responses_api" not in captured
 
 
-def test_routes_openai_through_openrouter_when_missing_key(monkeypatch):
+@pytest.mark.parametrize(
+    ("model_name", "expected_openrouter_name"),
+    [
+        ("gpt-4.1", "openai/gpt-4.1"),
+        ("gpt-4o", "openai/gpt-4o"),
+        ("gpt-4o-mini", "openai/gpt-4o-mini"),
+        ("o3", "openai/o3"),
+        ("o3-mini", "openai/o3-mini"),
+        ("o4-mini", "openai/o4-mini"),
+        ("gpt-5", "openai/gpt-5.1"),
+        ("gpt-5-mini", "openai/gpt-5-mini"),
+    ],
+)
+def test_routes_openai_through_openrouter_when_missing_key(
+    monkeypatch, model_name, expected_openrouter_name
+):
     config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
     monkeypatch.setattr(model_config, "get_config", lambda: config)
-    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("gpt-4o"))
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings(model_name))
 
     captured = {}
 
@@ -89,16 +104,17 @@ def test_routes_openai_through_openrouter_when_missing_key(monkeypatch):
 
     ModelSelector.get_llm(AgentRole.SUMMARIZER)
 
-    assert captured["model"] == "openai/gpt-4o"
+    assert captured["model"] == expected_openrouter_name
     assert captured["api_key"] == "sk-or-test"
     assert captured["base_url"] == "https://openrouter.ai/api/v1"
     assert "use_responses_api" not in captured
 
 
-def test_routes_openai_gpt5_through_openrouter_and_strips_responses_api(monkeypatch):
+@pytest.mark.parametrize("model_name", ["gpt-5", "gpt-5-mini"])
+def test_openai_responses_params_stripped_for_openrouter(monkeypatch, model_name):
     config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
     monkeypatch.setattr(model_config, "get_config", lambda: config)
-    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("gpt-5"))
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings(model_name))
 
     captured = {}
 
@@ -114,16 +130,17 @@ def test_routes_openai_gpt5_through_openrouter_and_strips_responses_api(monkeypa
 
     ModelSelector.get_llm(AgentRole.SUMMARIZER)
 
-    assert captured["model"] == "openai/gpt-5.1"
-    assert captured["api_key"] == "sk-or-test"
     assert captured["base_url"] == "https://openrouter.ai/api/v1"
     assert "use_responses_api" not in captured
+    assert "reasoning" not in captured
+    assert "model_kwargs" not in captured
 
 
-def test_openai_model_without_openrouter_alias_requires_openai_key(monkeypatch):
+@pytest.mark.parametrize("model_name", ["gpt-4.5", "o1", "o1-mini"])
+def test_openai_model_without_openrouter_alias_requires_openai_key(monkeypatch, model_name):
     config = Config(openrouter_api_key="sk-or-test", ai_mode=AIMode.STANDARD)
     monkeypatch.setattr(model_config, "get_config", lambda: config)
-    monkeypatch.setattr(model_config, "ai_settings", _StubSettings("gpt-4.5"))
+    monkeypatch.setattr(model_config, "ai_settings", _StubSettings(model_name))
 
     monkeypatch.setattr(model_config, "ChatOpenAI", lambda **_kwargs: None)
     monkeypatch.setattr(model_config, "ChatAnthropic", lambda **_kwargs: None)


### PR DESCRIPTION
Was doing some testing - and thought the OpenRouter support could be improved?

----
**Changes**

1. Aliases are added to support OpenRouter - and bypass the need for hardcoded variants: ModelConfiguration now carries optional openrouter_name so Anthropic models use the correct OpenRouter IDs (e.g., claude-sonnet-4.5) when falling back without an Anthropic key.
2. OpenAI entries now mark which ones OpenRouter supports; fallback routes only those with an alias (gpt-4.1, gpt-4o, gpt-4o-mini, o3, o3-mini, o4-mini, gpt-5.1, gpt-5-mini) and errors clearly for unsupported ones (gpt-4.5-preview, o1, o1-mini)
3. Fallbacks strip OpenAI-only params (Responses API) and Anthropic-only params (thinking) when routed through OpenRouter to avoid 400s
4. Tests expanded to cover Anthropic aliasing, OpenAI fallbacks (including gpt-5), and “no alias” guard